### PR TITLE
Update for WIF

### DIFF
--- a/Glimpse.ClaimsInspector/ClaimsInspector.cs
+++ b/Glimpse.ClaimsInspector/ClaimsInspector.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using Glimpse.AspNet.Extensions;
 using Glimpse.Core.Extensibility;
-using Microsoft.IdentityModel.Claims;
+using System.Security.Claims;
 
 namespace Glimpse.ClaimsInspector
 {
@@ -13,10 +13,10 @@ namespace Glimpse.ClaimsInspector
             var res = new List<string[]> { new[] { "Subject", "Type", "Value", "Value Type", "Issuer", "Original Issuer" } };
             var httpContext = context.GetHttpContext();
 
-            var iPrincipal = (IClaimsPrincipal)httpContext.User;
-            var identity = (IClaimsIdentity)iPrincipal.Identity;
+            var iPrincipal = (ClaimsPrincipal)httpContext.User;
+            var identity = (ClaimsIdentity)iPrincipal.Identity;
 
-            res.AddRange(identity.Claims.Select(c => new[] {  c.Subject==null?string.Empty:c.Subject.ToString(),c.ClaimType, 
+            res.AddRange(identity.Claims.Select(c => new[] {  c.Subject==null?string.Empty:c.Subject.ToString(),c.Type, 
                 c.Value, c.ValueType, c.Issuer ,c.OriginalIssuer }));
 
             return res;

--- a/Glimpse.ClaimsInspector/Glimpse.ClaimsInspector.csproj
+++ b/Glimpse.ClaimsInspector/Glimpse.ClaimsInspector.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Glimpse.ClaimsInspector</RootNamespace>
     <AssemblyName>Glimpse.ClaimsInspector</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -31,6 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Glimpse.AspNet">
@@ -39,9 +41,10 @@
     <Reference Include="Glimpse.Core">
       <HintPath>..\packages\Glimpse.1.2.0\lib\net40\Glimpse.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IdentityModel" />
+    <Reference Include="System.IdentityModel.Selectors" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/Glimpse.ClaimsInspector/Properties/AssemblyInfo.cs
+++ b/Glimpse.ClaimsInspector/Properties/AssemblyInfo.cs
@@ -8,9 +8,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Glimpse.ClaimsInspector")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Microsoft")]
+//[assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Glimpse.ClaimsInspector")]
-[assembly: AssemblyCopyright("Copyright © Microsoft 2013")]
+//[assembly: AssemblyCopyright("Copyright © Microsoft 2013")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+Glimpse.ClaimsInspector (WIF fork)
+=======================
+
+This is a tweak of Chris' ClaimsInspector to expose WIF claims in System.IdentityModel rather than the 3.5 Microsoft.IdentityModel. I'm using this with Azure AD Authentication. 
+
+Exposes System.IdentityModel.Claims in Glimpse.  This can be used to display WIF claims client side through Glimpse, including Azure AD and Azure ACS claims.


### PR DESCRIPTION
I tweaked the ClaimsInspector (and references) to use System.IdentityModel for .NET 4.5 development, including Azure AD development. Microsoft.IdentityModel works only for the older WIF framework before it was moved into System in .NET 4.5 (or 4.0?). 
